### PR TITLE
Stops enter key from clearing filter on commands page

### DIFF
--- a/public/commands/index.html
+++ b/public/commands/index.html
@@ -72,7 +72,7 @@
 <body>
   <p class="info">Coding Garden Cloudbot Chat Commands</p>
   <div id="app">
-    <form>
+    <form @submit.prevent>
       <label>Filter Commands</label>
       <input v-model="filter">
     </form>


### PR DESCRIPTION
I was searching for commands on the website, and accidentally pressed the enter key, which at the moment clears the filter. This PR prevents the default form behaviour.