### PR TITLE
Fix for Dark-Reader

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -170,9 +170,12 @@
 	}
 
 	.link-list a img {
-		z-index: -1;
 		max-width: 242px;
 		transition-duration: 500ms;
+	}
+
+	.link-list a span {
+		z-index: 1;
 	}
 
 	.link-list a:hover {


### PR DESCRIPTION
Activating Dark-Reader on the website caused all the icons on the front page to disappear.

Looks like the reason was the z-index (I believe it was there so the image didn't cover the text when it grows as you hover)

The final real fix would be to use the SVGs posted in this issue. https://github.com/CodingGarden/coding.garden/issues/14