### PR TITLE
Install Clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Landing page built with [SvelteKit](https://kit.svelte.dev/).
 ## Setup
 
 ```bash
-npm install
+npm install-clean
 ```
 
 ## Development


### PR DESCRIPTION
Given that the project has some packages versioned as "next" example:

```json
"@sveltejs/adapter-auto": "next",
"@sveltejs/kit": "next",
```

When following the readme it tells us to use `npm install` but that causes issues as it installs newer versions (with breaking changes)

The command to use should be `npm install-clean` this forces npm to use the `package-lock.json`

https://docs.npmjs.com/cli/v9/commands/npm-ci

Also, and to not open a separate issue. SvelteKit should be updated to use an specific version now that it's out of beta (IMO)

